### PR TITLE
feat: Add Edge TTS cloud voice service support

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -2337,3 +2337,63 @@ input:checked + .toggle-slider:before {
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* Edge TTS 设置样式 */
+.edge-tts-section {
+  margin-top: 24px;
+}
+
+.edge-tts-toggle {
+  margin-bottom: 0;
+}
+
+.edge-tts-config .voice-settings {
+  background: var(--bg-tertiary);
+}
+
+.edge-tts-config .voice-setting-row input[type="url"],
+.edge-tts-config .voice-setting-row input[type="password"],
+.edge-tts-config .voice-setting-row input[type="text"] {
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.edge-tts-config .voice-setting-row input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.edge-tts-config .input-with-toggle {
+  position: relative;
+  display: flex;
+}
+
+.edge-tts-config .input-with-toggle input {
+  flex: 1;
+  padding-right: 40px;
+}
+
+.edge-tts-config .toggle-visibility {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+}
+
+.edge-tts-config .toggle-visibility:hover {
+  color: var(--text-primary);
+}
+
+.edge-tts-result {
+  font-size: 14px;
+  font-weight: 500;
+}

--- a/js/offscreen.js
+++ b/js/offscreen.js
@@ -1,0 +1,85 @@
+/**
+ * VocabMeld Offscreen Audio Player
+ *
+ * This script runs in an offscreen document to handle audio playback.
+ * Manifest V3 Service Workers cannot use the Audio API directly,
+ * so we use this offscreen document to play TTS audio from Edge TTS API.
+ */
+
+let currentAudio = null;
+
+// Listen for messages from the background script
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'playAudio') {
+    playAudio(message.audioData, message.mimeType)
+      .then(result => sendResponse(result))
+      .catch(error => sendResponse({ success: false, error: error.message }));
+    return true; // Keep the message channel open for async response
+  }
+
+  if (message.action === 'stopAudio') {
+    stopAudio();
+    sendResponse({ success: true });
+    return false;
+  }
+});
+
+/**
+ * Play audio from base64 data
+ * @param {string} base64Data - Base64 encoded audio data
+ * @param {string} mimeType - MIME type of the audio (e.g., 'audio/mpeg')
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+async function playAudio(base64Data, mimeType) {
+  try {
+    // Stop any currently playing audio
+    stopAudio();
+
+    // Convert base64 to blob
+    const binaryString = atob(base64Data);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    const blob = new Blob([bytes], { type: mimeType || 'audio/mpeg' });
+
+    // Create audio URL and play
+    const audioUrl = URL.createObjectURL(blob);
+    currentAudio = new Audio(audioUrl);
+
+    return new Promise((resolve) => {
+      currentAudio.onended = () => {
+        URL.revokeObjectURL(audioUrl);
+        currentAudio = null;
+        resolve({ success: true });
+      };
+
+      currentAudio.onerror = (e) => {
+        URL.revokeObjectURL(audioUrl);
+        currentAudio = null;
+        resolve({ success: false, error: 'Audio playback failed: ' + (e.message || 'Unknown error') });
+      };
+
+      currentAudio.play().catch(error => {
+        URL.revokeObjectURL(audioUrl);
+        currentAudio = null;
+        resolve({ success: false, error: 'Failed to play audio: ' + error.message });
+      });
+    });
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Stop currently playing audio
+ */
+function stopAudio() {
+  if (currentAudio) {
+    currentAudio.pause();
+    currentAudio.src = '';
+    currentAudio = null;
+  }
+}
+
+console.log('[VocabMeld] Offscreen audio player loaded');

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
     "storage",
     "activeTab",
     "contextMenus",
-    "tts"
+    "tts",
+    "offscreen"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>VocabMeld Audio Player</title>
+</head>
+<body>
+  <!--
+    Offscreen document for audio playback.
+    Manifest V3 Service Workers cannot use Audio API directly,
+    so we use an offscreen document for TTS audio playback.
+  -->
+  <script src="js/offscreen.js"></script>
+</body>
+</html>

--- a/options.html
+++ b/options.html
@@ -269,6 +269,111 @@
             </div>
           </div>
         </div>
+
+        <!-- Edge TTS 云端语音服务 -->
+        <div class="form-group edge-tts-section">
+          <label>Edge TTS 云端语音</label>
+          <p class="help-text">使用 Edge TTS 云端服务获得更自然的发音效果。需要自行部署服务端：<a href="https://github.com/snakeying/edgetts-cloudflare" target="_blank">edgetts-cloudflare</a></p>
+
+          <div class="toggle-item edge-tts-toggle">
+            <div class="toggle-info">
+              <span class="toggle-title">启用 Edge TTS</span>
+              <span class="toggle-desc">使用云端语音服务替代系统语音</span>
+            </div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="edgeTtsEnabled">
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="edge-tts-config" id="edgeTtsConfig" style="display: none;">
+            <div class="voice-settings" style="margin-top: 16px;">
+              <div class="voice-setting-row">
+                <label for="edgeTtsEndpoint">服务端点</label>
+                <input type="url" id="edgeTtsEndpoint" placeholder="https://your-worker.workers.dev/" style="flex: 1;">
+              </div>
+              <div class="voice-setting-row">
+                <label for="edgeTtsApiKey">API 密钥</label>
+                <div class="input-with-toggle" style="flex: 1;">
+                  <input type="password" id="edgeTtsApiKey" placeholder="可选">
+                  <button type="button" class="toggle-visibility" id="toggleEdgeTtsApiKey">
+                    <svg viewBox="0 0 24 24" width="18" height="18">
+                      <path fill="currentColor" d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"/>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div class="voice-setting-row">
+                <label for="edgeTtsVoice">声音</label>
+                <select id="edgeTtsVoice" style="flex: 1;">
+                  <optgroup label="English">
+                    <option value="en-US-AriaNeural">Aria (温柔女声)</option>
+                    <option value="en-US-JennyNeural">Jenny (标准女声)</option>
+                    <option value="en-US-GuyNeural">Guy (标准男声)</option>
+                    <option value="en-US-ChristopherNeural">Christopher (沉稳男声)</option>
+                    <option value="en-GB-SoniaNeural">Sonia (英式女声)</option>
+                    <option value="en-GB-RyanNeural">Ryan (英式男声)</option>
+                  </optgroup>
+                  <optgroup label="简体中文">
+                    <option value="zh-CN-XiaoxiaoNeural">晓晓 (温柔女声)</option>
+                    <option value="zh-CN-YunxiNeural">云希 (活泼男声)</option>
+                    <option value="zh-CN-YunjianNeural">云健 (标准男声)</option>
+                    <option value="zh-CN-XiaoyiNeural">晓伊 (甜美女声)</option>
+                  </optgroup>
+                  <optgroup label="繁體中文">
+                    <option value="zh-TW-HsiaoChenNeural">曉臻 (女声)</option>
+                    <option value="zh-TW-YunJheNeural">雲哲 (男声)</option>
+                    <option value="zh-TW-HsiaoYuNeural">曉雨 (女声)</option>
+                  </optgroup>
+                  <optgroup label="日本語">
+                    <option value="ja-JP-NanamiNeural">Nanami (女声)</option>
+                    <option value="ja-JP-KeitaNeural">Keita (男声)</option>
+                  </optgroup>
+                  <optgroup label="한국어">
+                    <option value="ko-KR-SunHiNeural">SunHi (女声)</option>
+                    <option value="ko-KR-InJoonNeural">InJoon (男声)</option>
+                  </optgroup>
+                  <optgroup label="Français">
+                    <option value="fr-FR-DeniseNeural">Denise (女声)</option>
+                    <option value="fr-FR-HenriNeural">Henri (男声)</option>
+                  </optgroup>
+                  <optgroup label="Deutsch">
+                    <option value="de-DE-KatjaNeural">Katja (女声)</option>
+                    <option value="de-DE-ConradNeural">Conrad (男声)</option>
+                  </optgroup>
+                  <optgroup label="Español">
+                    <option value="es-ES-ElviraNeural">Elvira (女声)</option>
+                    <option value="es-ES-AlvaroNeural">Alvaro (男声)</option>
+                  </optgroup>
+                </select>
+              </div>
+              <div class="voice-setting-row">
+                <label for="edgeTtsSpeed">语速 (<span id="edgeTtsSpeedValue">1.0</span>x)</label>
+                <input type="range" id="edgeTtsSpeed" min="0.5" max="2" step="0.1" value="1.0" style="flex: 1;">
+              </div>
+              <div class="voice-setting-row">
+                <label></label>
+                <div style="display: flex; gap: 8px; flex: 1;">
+                  <button type="button" class="btn btn-secondary" id="testEdgeTtsBtn" style="flex: 1;">
+                    <svg viewBox="0 0 24 24" width="16" height="16">
+                      <path fill="currentColor" d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M11,16.5L18,9.5L16.59,8.09L11,13.67L7.91,10.59L6.5,12L11,16.5Z"/>
+                    </svg>
+                    测试连接
+                  </button>
+                  <button type="button" class="btn btn-secondary" id="testEdgeTtsVoiceBtn" style="flex: 1;">
+                    <svg viewBox="0 0 24 24" width="16" height="16">
+                      <path fill="currentColor" d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z"/>
+                    </svg>
+                    测试发音
+                  </button>
+                </div>
+              </div>
+              <div class="voice-setting-row" style="border-bottom: none;">
+                <span class="edge-tts-result" id="edgeTtsResult"></span>
+              </div>
+            </div>
+          </div>
+        </div>
       </section>
 
       <!-- 行为设置 -->


### PR DESCRIPTION
## Summary
- Add Edge TTS cloud voice service support, allowing users to use self-deployed [edgetts-cloudflare](https://github.com/snakeying/edgetts-cloudflare) for more natural speech synthesis
- Fix audio playback issue in Manifest V3 by implementing Offscreen API
- Add configuration UI for Edge TTS in the options page

## Changes
- Add `offscreen.html` and `js/offscreen.js` for audio playback (Manifest V3 Service Workers cannot use Audio API directly)
- Modify `js/background.js` to add Edge TTS API integration with fallback to system TTS
- Modify `options.html` and `js/options.js` to add Edge TTS configuration section
- Add "offscreen" permission to `manifest.json`
- Add Edge TTS styling to `css/options.css`

## Features
- Enable/disable Edge TTS toggle
- Configurable service endpoint and API key
- Multiple voice presets for various languages (English, Chinese, Japanese, Korean, French, German, Spanish)
- Adjustable speech speed
- Connection test and voice test buttons
- Automatic fallback to system TTS when Edge TTS fails

## Reference
- Edge TTS Cloudflare Worker: https://github.com/snakeying/edgetts-cloudflare

## Test plan
- [ ] Enable Edge TTS and configure endpoint
- [ ] Test connection button works
- [ ] Test voice playback works
- [ ] Verify fallback to system TTS when Edge TTS is disabled
- [ ] Verify audio plays correctly on web pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)